### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,36 +20,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../paper-dialog-scrollable.html">
+  <link rel="import" href="../../paper-styles/typography.html">
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
 
-  <link rel="import" href="../../paper-styles/classes/typography.html">
-  <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
-
-  <style>
+  <style is="custom-style">
+    body {
+      @apply(--layout-fullbleed);
+    }
 
     section {
       height: 100%;
+      @apply(--layout-vertical);
     }
 
-    .header, .footer {
+    .header {
       padding: 8px 24px;
+      @apply(--paper-font-title);
     }
 
     .footer {
+      padding: 8px 24px;
       text-align: right;
+      @apply(--paper-font-subhead);
+    }
+
+    paper-dialog-scrollable {
+      @apply(--layout-flex);
+      @apply(--paper-font-body1);
     }
 
   </style>
 
 </head>
-<body class="fullbleed">
+<body unresolved>
 
-  <section class="layout vertical">
+  <section>
 
-    <div class="header paper-font-title">
+    <div class="header">
       Alice in Wonderland
     </div>
 
-    <paper-dialog-scrollable class="flex paper-font-body1">
+    <paper-dialog-scrollable>
 
         <p>Alice was beginning to get very tired of sitting by her sister
       on the bank, and of having nothing to do: once or twice she had
@@ -280,7 +291,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     </paper-dialog-scrollable>
 
-    <div class="footer paper-font-subhead">
+    <div class="footer">
       Lewis Carroll
     </div>
 

--- a/paper-dialog-scrollable.html
+++ b/paper-dialog-scrollable.html
@@ -9,8 +9,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../paper-styles/default-theme.html">
 
 <!--
 Material design: [Dialogs](https://www.google.com/design/spec/components/dialogs.html)
@@ -73,8 +73,11 @@ is hidden if it is scrolled to the bottom.
       padding: 0 24px;
 
       @apply(--layout-scroll);
-
       @apply(--paper-dialog-scrollable);
+    }
+
+    .fit {
+      @apply(--layout-fit);
     }
   </style>
 

--- a/test/paper-dialog-scrollable.html
+++ b/test/paper-dialog-scrollable.html
@@ -20,16 +20,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
-
-    <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../paper-dialog-scrollable.html">
+    <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
 
-    <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
-
-    <style>
+    <style is="custom-style">
       .fixed-height {
         height: 400px;
+        @apply(--layout-vertical);
+      }
+      paper-dialog-scrollable {
+        @apply(--layout-flex)
       }
     </style>
 
@@ -38,9 +38,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="basic">
       <template>
-        <section class="fixed-height layout vertical">
+        <section class="fixed-height vertical">
           <div class="header">Header</div>
-          <paper-dialog-scrollable class="flex">
+          <paper-dialog-scrollable>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -57,8 +57,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="only-child">
       <template>
-        <section class="fixed-height layout vertical">
-          <paper-dialog-scrollable class="flex">
+        <section class="fixed-height">
+          <paper-dialog-scrollable>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -74,9 +74,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="short">
       <template>
-        <section class="fixed-height layout vertical">
+        <section class="fixed-height">
           <div class="header">Header</div>
-          <paper-dialog-scrollable class="flex">
+          <paper-dialog-scrollable>
             <p>Hello world!</p>
           </paper-dialog-scrollable>
           <div class="footer">Footer</div>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way
