### PR TITLE
read parentNode on attached in order to support dynamically created elements

### DIFF
--- a/paper-dialog-scrollable.html
+++ b/paper-dialog-scrollable.html
@@ -102,10 +102,7 @@ is hidden if it is scrolled to the bottom.
        * @type {?Node}
        */
       dialogElement: {
-        type: Object,
-        value: function() {
-          return this.parentNode;
-        }
+        type: Object
       }
 
     },
@@ -123,6 +120,9 @@ is hidden if it is scrolled to the bottom.
 
     attached: function() {
       this.classList.add('no-padding');
+      // read parentNode on attached because if dynamically created,
+      // parentNode will be null on creation.
+      this.dialogElement = this.dialogElement || Polymer.dom(this).parentNode;
       // Set itself to the overlay sizing target
       this.dialogElement.sizingTarget = this.scrollTarget;
       // If the host is sized, fit the scrollable area to the container. Otherwise let it be

--- a/test/paper-dialog-scrollable.html
+++ b/test/paper-dialog-scrollable.html
@@ -163,6 +163,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }, 10);
         });
 
+        test('can be added dynamically', function(done) {
+          var scrollable = document.createElement('paper-dialog-scrollable');
+          document.body.appendChild(scrollable);
+          setTimeout(function() {
+            assert.isTrue(scrollable.dialogElement === document.body, 'dialogElement is body');
+            document.body.removeChild(scrollable);
+            done();
+          }, 10);
+        });
+
       });
 
     </script>


### PR DESCRIPTION
Fixes #22 by reading `parentNode` on `attached`
