### PR TITLE
ensure target is set on ready

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
+    "paper-dialog": "PolymerElements/paper-dialog#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",

--- a/paper-dialog-scrollable.html
+++ b/paper-dialog-scrollable.html
@@ -45,8 +45,12 @@ is hidden if it is scrolled to the bottom.
   <style>
 
     :host {
-      display: block;
-      position: relative;
+      /* Needed for correct flex rendering on Firefox & Chrome Canary */
+      min-height: 0;
+      max-height: 100%;
+
+      @apply(--layout);
+      @apply(--layout-relative);
     }
 
     :host(.is-scrolled:not(:first-child))::before {
@@ -72,12 +76,9 @@ is hidden if it is scrolled to the bottom.
     .scrollable {
       padding: 0 24px;
 
+      @apply(--layout-flex);
       @apply(--layout-scroll);
       @apply(--paper-dialog-scrollable);
-    }
-
-    .fit {
-      @apply(--layout-fit);
     }
   </style>
 
@@ -118,21 +119,14 @@ is hidden if it is scrolled to the bottom.
       return this.$.scrollable;
     },
 
+    ready: function () {
+      this._ensureTarget();
+    },
+
     attached: function() {
       this.classList.add('no-padding');
-      // read parentNode on attached because if dynamically created,
-      // parentNode will be null on creation.
-      this.dialogElement = this.dialogElement || Polymer.dom(this).parentNode;
-      // Set itself to the overlay sizing target
-      this.dialogElement.sizingTarget = this.scrollTarget;
-      // If the host is sized, fit the scrollable area to the container. Otherwise let it be
-      // its natural size.
-      requestAnimationFrame(function() {
-        if (this.offsetHeight > 0) {
-          this.$.scrollable.classList.add('fit');
-        }
-        this._scroll();
-      }.bind(this));
+      this._ensureTarget();
+      requestAnimationFrame(this._scroll.bind(this));
     },
 
     _scroll: function() {
@@ -140,6 +134,16 @@ is hidden if it is scrolled to the bottom.
       this.toggleClass('can-scroll', this.scrollTarget.offsetHeight < this.scrollTarget.scrollHeight);
       this.toggleClass('scrolled-to-bottom',
         this.scrollTarget.scrollTop + this.scrollTarget.offsetHeight >= this.scrollTarget.scrollHeight);
+    },
+
+    _ensureTarget: function () {
+      // read parentNode on attached because if dynamically created,
+      // parentNode will be null on creation.
+      this.dialogElement = this.dialogElement || Polymer.dom(this).parentNode;
+      // Set itself to the overlay sizing target
+      if (this.dialogElement) {
+        this.dialogElement.sizingTarget = this.scrollTarget;
+      }
     }
 
   });

--- a/test/paper-dialog-scrollable.html
+++ b/test/paper-dialog-scrollable.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../web-component-tester/browser.js"></script>
     <link rel="import" href="../paper-dialog-scrollable.html">
     <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
+    <link rel="import" href="../../paper-dialog/paper-dialog.html">
 
     <style is="custom-style">
       .fixed-height {
@@ -81,6 +82,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </paper-dialog-scrollable>
           <div class="footer">Footer</div>
         </section>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="dialog">
+      <template>
+        <paper-dialog opened>
+          <h2>Dialog</h2>
+          <paper-dialog-scrollable>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </paper-dialog-scrollable>
+          <div class="buttons">
+            <button dialog-dismiss>close</button>
+          </div>
+        </paper-dialog>
       </template>
     </test-fixture>
 
@@ -171,6 +186,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             document.body.removeChild(scrollable);
             done();
           }, 10);
+        });
+
+        test('paper-dialog-scrollable has the right size if paper-dialog is created opened', function(done) {
+          var dialog = fixture('dialog');
+          // Wait for dialog to be opened and styles applied.
+          setTimeout(function () {
+            var scrollable = Polymer.dom(dialog).querySelector('paper-dialog-scrollable');
+            assert.notEqual(scrollable.getBoundingClientRect().height, 0);
+            done();
+          }, 20);
         });
 
       });


### PR DESCRIPTION
Fixes #13, fixes #27 by ensuring the sizing target is set on `ready` (since `iron-overlay-behavior`'s method `attached` is called before the one of `paper-dialog-scrollable`), and using `flex` instead of `fit` to size the internal `scrollable` element.
`min-height, max-height` is needed for a correct sizing on Firefox v 43.0.2 (mac os) and Chrome Canary v49.0.2618.0 (mac os)

Also fixes https://code.google.com/p/chromium/issues/detail?id=578183
