### PR TITLE
Mixin in docs. Reminder to set dialogElement in docs

### DIFF
--- a/paper-dialog-scrollable.html
+++ b/paper-dialog-scrollable.html
@@ -34,6 +34,34 @@ indicating there is more content above. It shows a bottom divider if it is scrol
 the last child in its parent container, indicating there is more content below. The bottom divider
 is hidden if it is scrolled to the bottom.
 
+If `paper-dialog-scrollable` is not a direct child of the element implementing `Polymer.PaperDialogBehavior`,
+remember to set the `dialogElement`:
+
+    <paper-dialog-impl id="myDialog">
+      <h2>Header</h2>
+      <div class="my-content-wrapper">
+        <h4>Sub-header</h4>
+        <paper-dialog-scrollable>
+          Lorem ipsum...
+        </paper-dialog-scrollable>
+      </div>
+      <div class="buttons">
+        <paper-button>OK</paper-button>
+      </div>
+    </paper-dialog-impl>
+
+    <script>
+      var scrollable = Polymer.dom(myDialog).querySelector('paper-dialog-scrollable');
+      scrollable.dialogElement = myDialog;
+    </script>
+
+### Styling
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--paper-dialog-scrollable` | Mixin for the scrollable content | {}
+
 @group Paper Elements
 @element paper-dialog-scrollable
 @demo demo/index.html


### PR DESCRIPTION
Fixes #28, Fixes #33 by updating the docs, that now have these 2 new parts:
<img width="805" alt="screen shot 2016-01-29 at 10 55 35 am" src="https://cloud.githubusercontent.com/assets/6173664/12685052/eba9ab9a-c676-11e5-83a8-129a434225fa.png">
