### PR TITLE
scrollable should not be flex

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,12 +22,14 @@
   "ignore": [],
   "dependencies": {
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
+    "paper-dialog-behavior": "PolymerElements/paper-dialog-behavior#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
+    "paper-button": "PolymerElements/paper-button#^1.0.0",
     "paper-dialog": "PolymerElements/paper-dialog#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,6 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../paper-dialog-scrollable.html">
 
+  <link rel="import" href="../../paper-dialog/paper-dialog.html">
+  <link rel="import" href="../../paper-button/paper-button.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 
@@ -42,8 +44,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <style is="custom-style">
         section {
+          width: 100%;
           height: 300px;
           @apply(--layout-vertical);
+        }
+        section paper-dialog-scrollable {
+          @apply(--layout-flex);
         }
         .header {
           padding: 8px 24px;
@@ -204,6 +210,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-dialog-scrollable>
         <div class="footer">Lewis Carroll</div>
       </section>
+    </template>
+  </demo-snippet>
+
+  <h3>
+    <code>paper-dialog-scrollable</code> can be contained in a <code>paper-dialog</code>
+  </h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <paper-button raised onclick="dialog.open()">Open</paper-button>
+      <paper-dialog id="dialog">
+        <h2>Scrollable</h2>
+        <paper-dialog-scrollable>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </paper-dialog-scrollable>
+        <div class="buttons">
+          <paper-button dialog-dismiss>Close</paper-button>
+        </div>
+      </paper-dialog>
     </template>
   </demo-snippet>
 

--- a/paper-dialog-scrollable.html
+++ b/paper-dialog-scrollable.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 
 <!--
@@ -73,11 +74,7 @@ Custom property | Description | Default
   <style>
 
     :host {
-      /* Needed for correct flex rendering on Firefox & Chrome Canary */
-      min-height: 0;
-      max-height: 100%;
-
-      @apply(--layout);
+      display: block;
       @apply(--layout-relative);
     }
 
@@ -104,9 +101,12 @@ Custom property | Description | Default
     .scrollable {
       padding: 0 24px;
 
-      @apply(--layout-flex);
       @apply(--layout-scroll);
       @apply(--paper-dialog-scrollable);
+    }
+
+    .fit {
+      @apply(--layout-fit);
     }
   </style>
 
@@ -168,9 +168,12 @@ Custom property | Description | Default
       // read parentNode on attached because if dynamically created,
       // parentNode will be null on creation.
       this.dialogElement = this.dialogElement || Polymer.dom(this).parentNode;
-      // Set itself to the overlay sizing target
-      if (this.dialogElement) {
+      // Check if parent implements paper-dialog-behavior. If not, fit scrollTarget to host.
+      if (this.dialogElement && this.dialogElement.behaviors &&
+          this.dialogElement.behaviors.indexOf(Polymer.PaperDialogBehaviorImpl) >= 0) {
         this.dialogElement.sizingTarget = this.scrollTarget;
+      } else if (this.dialogElement) {
+        this.scrollTarget.classList.add('fit');
       }
     }
 

--- a/test/paper-dialog-scrollable.html
+++ b/test/paper-dialog-scrollable.html
@@ -26,11 +26,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <style is="custom-style">
       .fixed-height {
+        width: 100%;
         height: 400px;
         @apply(--layout-vertical);
       }
-      paper-dialog-scrollable {
-        @apply(--layout-flex)
+      .fixed-height paper-dialog-scrollable {
+        @apply(--layout-flex);
       }
     </style>
 
@@ -39,7 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="basic">
       <template>
-        <section class="fixed-height vertical">
+        <section class="fixed-height">
           <div class="header">Header</div>
           <paper-dialog-scrollable>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -188,14 +189,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }, 10);
         });
 
-        test('paper-dialog-scrollable has the right size if paper-dialog is created opened', function(done) {
+        test('correctly sized (container = section)', function() {
+          var container = fixture('basic');
+          var scrollable = Polymer.dom(container).querySelector('paper-dialog-scrollable');
+          var cRect = container.getBoundingClientRect();
+          var sRect = scrollable.getBoundingClientRect();
+          var stRect = scrollable.scrollTarget.getBoundingClientRect();
+          assert.equal(sRect.width, cRect.width, 'scrollable width ok');
+          assert.isAbove(sRect.height, 0, 'scrollable height bigger than 0');
+          assert.isBelow(sRect.height, cRect.height, 'scrollable height contained in container height');
+          assert.equal(stRect.width, sRect.width, 'scrollTarget width ok');
+          assert.equal(stRect.height, sRect.height, 'scrollTarget height ok');
+        });
+
+        test('correctly sized (container = paper-dialog[opened])', function(done) {
           var dialog = fixture('dialog');
+          var scrollable = Polymer.dom(dialog).querySelector('paper-dialog-scrollable');
           // Wait for dialog to be opened and styles applied.
-          setTimeout(function () {
-            var scrollable = Polymer.dom(dialog).querySelector('paper-dialog-scrollable');
-            assert.notEqual(scrollable.getBoundingClientRect().height, 0);
+          dialog.addEventListener('iron-overlay-opened', function() {
+            var dRect = dialog.getBoundingClientRect();
+            var sRect = scrollable.getBoundingClientRect();
+            var stRect = scrollable.scrollTarget.getBoundingClientRect();
+            assert.equal(sRect.width, dRect.width, 'scrollable width ok');
+            assert.isAbove(sRect.height, 0, 'scrollable height bigger than 0');
+            assert.isBelow(sRect.height, dRect.height, 'scrollable height contained in dialog height');
+            assert.equal(stRect.width, sRect.width, 'scrollTarget width ok');
+            assert.equal(stRect.height, sRect.height, 'scrollTarget height ok');
             done();
-          }, 20);
+          });
         });
 
       });


### PR DESCRIPTION
Fixes #40 by not applying `--layout-flex` to `scrollTarget` and instead fitting it to `:host` when the parent doesn't implement `paper-dialog-behavior`.
Updated demo to include a `paper-dialog` too.
