### PR TITLE
Check parentElement to skip shadowRoots

### DIFF
--- a/paper-dialog-scrollable.html
+++ b/paper-dialog-scrollable.html
@@ -161,10 +161,9 @@ Custom property | Description | Default
     },
 
     _ensureTarget: function () {
-      // read parentNode on attached because if dynamically created,
-      // parentNode will be null on creation.
-      this.dialogElement = this.dialogElement || Polymer.dom(this).parentNode;
-      // Check if parent implements paper-dialog-behavior. If not, fit scrollTarget to host.
+      // Read parentElement instead of parentNode in order to skip shadowRoots.
+      this.dialogElement = this.dialogElement || this.parentElement;
+      // Check if dialog implements paper-dialog-behavior. If not, fit scrollTarget to host.
       if (this.dialogElement && this.dialogElement.behaviors &&
           this.dialogElement.behaviors.indexOf(Polymer.PaperDialogBehaviorImpl) >= 0) {
         this.dialogElement.sizingTarget = this.scrollTarget;

--- a/test/paper-dialog-scrollable.html
+++ b/test/paper-dialog-scrollable.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../paper-dialog-scrollable.html">
     <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
     <link rel="import" href="../../paper-dialog/paper-dialog.html">
+    <link rel="import" href="test-dialog.html">
 
     <custom-style><style is="custom-style">
       .fixed-height {
@@ -97,6 +98,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <button dialog-dismiss>close</button>
           </div>
         </paper-dialog>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="shadow">
+      <template>
+        <test-dialog opened>
+          <h2 slot="title">Dialog</h2>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </test-dialog>
       </template>
     </test-fixture>
 
@@ -230,6 +240,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.isTrue(scrollable.classList.contains('scrolled-to-bottom'), 'scrollable has scrolled-to-bottom class');
             done();
           }, 10);
+        });
+
+        test('correctly sized (container = test-dialog[opened])', function(done) {
+          var dialog = fixture('shadow');
+          var scrollable = dialog.$.scrollable;
+          // Wait for dialog to be opened and styles applied.
+          dialog.addEventListener('iron-overlay-opened', function() {
+            var dRect = dialog.getBoundingClientRect();
+            var sRect = scrollable.getBoundingClientRect();
+            var stRect = scrollable.scrollTarget.getBoundingClientRect();
+            assert.equal(sRect.width, dRect.width, 'scrollable width ok');
+            assert.isAbove(sRect.height, 0, 'scrollable height bigger than 0');
+            assert.isBelow(sRect.height, dRect.height, 'scrollable height contained in dialog height');
+            assert.equal(stRect.width, sRect.width, 'scrollTarget width ok');
+            assert.equal(stRect.height, sRect.height, 'scrollTarget height ok');
+            done();
+          });
         });
 
       });

--- a/test/test-dialog.html
+++ b/test/test-dialog.html
@@ -1,0 +1,25 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../paper-dialog-behavior/paper-dialog-behavior.html">
+
+<dom-module id="test-dialog">
+  <template>
+    <slot name="title"></slot>
+    <paper-dialog-scrollable id="scrollable">
+      <slot></slot>
+    </paper-dialog-scrollable>
+  </template>
+  <script>
+    Polymer({
+      is: 'test-dialog',
+      behaviors: [Polymer.PaperDialogBehavior]
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
Fixes #63. The problem faced by users is due to the fact that the `paper-dialog-scrollable` is hosted in a shadowRoot, hence its `parentNode` will be a document fragment. We could either check for `parentNode.host`, or rely on `parentElement` which will awesomely skip any shadow root and get us the actual host 🎉 .