### PR TITLE
Fix issue #73 by increasing `z-index` on `::before`

### DIFF
--- a/paper-dialog-scrollable.html
+++ b/paper-dialog-scrollable.html
@@ -87,6 +87,7 @@ Custom property | Description | Default
         right: 0;
         height: 1px;
         background: var(--divider-color);
+        z-index: 1;
       }
 
       :host(.can-scroll:not(.scrolled-to-bottom):not(:last-child))::after {


### PR DESCRIPTION
Increase z-index of the ::before element to stay on top of content elements.