### PR TITLE
add paper-layout-classes

### DIFF
--- a/paper-dialog-scrollable.js
+++ b/paper-dialog-scrollable.js
@@ -9,7 +9,7 @@ part of the polymer project is also subject to an additional IP rights grant
 found at http://polymer.github.io/PATENTS.txt
 */
 import '@polymer/polymer/polymer-legacy.js';
-import '@polymer/iron-flex-layout/iron-flex-layout.js';
+import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import '@polymer/paper-styles/default-theme.js';
 
 import {PaperDialogBehaviorImpl} from '@polymer/paper-dialog-behavior/paper-dialog-behavior.js';


### PR DESCRIPTION
With the 
import '@polymer/iron-flex-layout/iron-flex-layout.js'; i got this error then import the paper-dialog-scrollable:

GET http://localhost:8081/node_modules/@polymer/paper-dialog-scrollable/node_modules/@polymer/iron-flex-layout/iron-flex-layout.js 404 (Not Found)

Is not generating the path correctly, instead with iron-flex-layout-classes.js work fine